### PR TITLE
Limit word count on course descriptions in explore page

### DIFF
--- a/client/src/components/CourseCard.tsx
+++ b/client/src/components/CourseCard.tsx
@@ -12,6 +12,10 @@ type CourseCardProps = {
 };
 
 export const CourseCard = ({ course, className, query }: CourseCardProps) => {
+  const courseDescriptionShortened =
+    course.description.length > 400
+      ? course.description.slice(0, 400) + ' ...'
+      : course.description;
   return (
     <Link
       to={`/course/${courseIdToUrlParam(course._id)}`}
@@ -32,9 +36,9 @@ export const CourseCard = ({ course, className, query }: CourseCardProps) => {
         <CourseTerms course={course} variant='small' query={query} />
         <div className='mt-2 text-gray-600 dark:text-gray-400'>
           {query ? (
-            <Highlight text={course.description} query={query} />
+            <Highlight text={courseDescriptionShortened} query={query} />
           ) : (
-            course.description
+            courseDescriptionShortened
           )}
         </div>
       </div>

--- a/client/src/components/CourseCard.tsx
+++ b/client/src/components/CourseCard.tsx
@@ -36,7 +36,7 @@ export const CourseCard = ({ course, className, query }: CourseCardProps) => {
         <CourseTerms course={course} variant='small' query={query} />
         <div className='mt-2 text-gray-600 dark:text-gray-400'>
           {query ? (
-            <Highlight text={courseDescriptionShortened} query={query} />
+            <Highlight text={course.description} query={query} />
           ) : (
             courseDescriptionShortened
           )}


### PR DESCRIPTION
String length for course cards have been limited to 400 characters
<img width="589" alt="CleanShot 2023-10-24 at 14 27 06@2x" src="https://github.com/terror/mcgill.courses/assets/112342947/f84f0cda-7b52-4572-a86d-fa749a2ad2f5">

