### PR TITLE
Add 'explore all courses' option to home page

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,26 @@ You'll need [docker](https://www.docker.com/),
 on your machine to spawn the various components the project needs to run
 locally.
 
-First, mount a local [mongodb](https://www.mongodb.com/) instance with docker:
+First, join the discord server to get access to the development environment
+variables:
+
+https://discord.gg/edfravxD
+
+In `.env` within the root directory you'll have to set
+
+```
+MS_CLIENT_ID=
+MS_CLIENT_SECRET=
+MS_REDIRECT_URI=http://localhost:8000/api/auth/authorized
+```
+
+...and then in `client/.env` you'll have to set the server url
+
+```
+VITE_API_URL=http://localhost:8000
+```
+
+Second, mount a local [mongodb](https://www.mongodb.com/) instance with docker:
 
 ```bash
 docker compose up -d
@@ -30,9 +49,6 @@ Finally, spawn the react frontend:
 pnpm install
 pnpm run dev
 ```
-
-Refer to `.env.dev.example` and `client/.env.dev.example` for what environment
-variables need to be set.
 
 _n.b._ If you have [just](https://github.com/casey/just) installed, we provide a
 `dev` recipe for doing all of the above in addition to running a watch on the

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -57,7 +57,7 @@ export const Home = () => {
               />
               <Link
                 to={`/explore`}
-                className='cursor-pointer text-sm text-gray-500 underline underline-offset-4 dark:text-gray-400 md:text-base'
+                className='cursor-pointer text-sm text-gray-500 underline underline-offset-4 hover:text-gray-400 dark:text-gray-400 dark:hover:text-gray-500 md:text-base'
               >
                 or explore all courses <span aria-hidden='true'>&rarr;</span>{' '}
               </Link>

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { useSearchParams } from 'react-router-dom';
+import { Link, useSearchParams } from 'react-router-dom';
 import { toast } from 'sonner';
 
 import { CourseSearchBar } from '../components/CourseSearchBar';
@@ -45,8 +45,8 @@ export const Home = () => {
       <div className='relative isolate px-6 pt-14 lg:px-8'>
         <div className='mx-auto max-w-2xl py-8'>
           <div className='hidden sm:mb-8 sm:flex sm:justify-center'></div>
-          <div className='text-center'>
-            <h1 className='mb-6 py-3 text-left text-3xl font-bold tracking-tight text-gray-900 dark:text-gray-200 md:text-5xl'>
+          <div className='flex flex-col gap-12 text-center'>
+            <h1 className='text-left text-3xl font-bold tracking-tight text-gray-900 dark:text-gray-200 md:text-5xl'>
               Explore thousands of course and professor reviews from McGill
               students
             </h1>
@@ -54,6 +54,12 @@ export const Home = () => {
               results={results}
               handleInputChange={handleInputChange}
             />
+            <Link
+              to={`/explore`}
+              className='cursor-pointer text-base text-gray-500 underline underline-offset-4 dark:text-gray-400'
+            >
+              or explore all courses <span aria-hidden='true'>&rarr;</span>{' '}
+            </Link>
           </div>
         </div>
       </div>

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -56,7 +56,7 @@ export const Home = () => {
             />
             <Link
               to={`/explore`}
-              className='cursor-pointer text-base text-gray-500 underline underline-offset-4 dark:text-gray-400'
+              className='cursor-pointer text-gray-500 underline underline-offset-4 dark:text-gray-400'
             >
               or explore all courses <span aria-hidden='true'>&rarr;</span>{' '}
             </Link>

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -45,21 +45,23 @@ export const Home = () => {
       <div className='relative isolate px-6 pt-14 lg:px-8'>
         <div className='mx-auto max-w-2xl py-8'>
           <div className='hidden sm:mb-8 sm:flex sm:justify-center'></div>
-          <div className='flex flex-col gap-12 text-center'>
+          <div className='flex flex-col gap-10 text-center'>
             <h1 className='text-left text-3xl font-bold tracking-tight text-gray-900 dark:text-gray-200 md:text-5xl'>
               Explore thousands of course and professor reviews from McGill
               students
             </h1>
-            <CourseSearchBar
-              results={results}
-              handleInputChange={handleInputChange}
-            />
-            <Link
-              to={`/explore`}
-              className='cursor-pointer text-gray-500 underline underline-offset-4 dark:text-gray-400'
-            >
-              or explore all courses <span aria-hidden='true'>&rarr;</span>{' '}
-            </Link>
+            <div className='flex flex-col gap-6 text-center'>
+              <CourseSearchBar
+                results={results}
+                handleInputChange={handleInputChange}
+              />
+              <Link
+                to={`/explore`}
+                className='cursor-pointer text-sm text-gray-500 underline underline-offset-4 dark:text-gray-400 md:text-base'
+              >
+                or explore all courses <span aria-hidden='true'>&rarr;</span>{' '}
+              </Link>
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Simple addition stemming from a small annoyance I was having with the UX. The 'explore all courses' seems like it is a very common use-case, instead of needing two clicks (input > "Explore all courses"), simply add an option below the search bar on the homepage for quick, one-click only, access. Option remains on input as well.

<img width="1473" alt="image" src="https://github.com/terror/mcgill.courses/assets/34781348/4a4e6c41-ffc1-45ac-b295-24511983dfc6">
