### PR TITLE
Fix cards in review page only rounding bottom

### DIFF
--- a/client/src/pages/Reviews.tsx
+++ b/client/src/pages/Reviews.tsx
@@ -89,13 +89,15 @@ export const Reviews = () => {
                       new Date(parseInt(review.timestamp.$date.$numberLong))
                     )}
                   </p>
-                  <CourseReview
-                    key={i}
-                    canModify={false}
-                    review={review}
-                    openEditReview={() => undefined}
-                    handleDelete={() => undefined}
-                  />
+                  <div>
+                    <CourseReview
+                      key={i}
+                      canModify={false}
+                      review={review}
+                      openEditReview={() => undefined}
+                      handleDelete={() => undefined}
+                    />
+                  </div>
                 </div>
               ))}
               {!hasMore ? (


### PR DESCRIPTION
The review cards in the review pages were only rounding the bottom because of the tailwind first: and last: status.
Fixed it so its rounding all four corners.
