### PR TITLE
Fix forks failing CI due to lack of Github secrets

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - master
-  pull_request:
+  pull_request_target:
     branches:
       - master
 


### PR DESCRIPTION
This should only be merged after @liam changes the OAuth secret to the dev one.
This has some security implications, because it means the CI will be ran on our resources. Github action codes from forks should be verified to ensure no malicious code before running any actions.

