### PR TITLE
Contrast background and reviews in dark mode notification dropdown

### DIFF
--- a/client/src/components/NotificationDropdown.tsx
+++ b/client/src/components/NotificationDropdown.tsx
@@ -125,7 +125,7 @@ export const NotificationDropdown = ({
                 leaveFrom='transform opacity-100 scale-100'
                 leaveTo='transform opacity-0 scale-95'
               >
-                <Menu.Items className='autocomplete absolute -right-8 z-30 mt-2 max-h-[800px] max-w-[325px] origin-top-right divide-y divide-gray-100 overflow-auto rounded-md bg-slate-100 shadow-lg dark:bg-neutral-800 md:max-w-[800px]'>
+                <Menu.Items className='autocomplete absolute -right-8 z-30 mt-2 max-h-[800px] max-w-[325px] origin-top-right divide-y divide-gray-100 overflow-auto rounded-md bg-slate-100 shadow-lg dark:bg-neutral-900 md:max-w-[800px]'>
                   <div className='p-2'>
                     {notifications.length !== 0 ? (
                       notifications.map((notification, i) => (


### PR DESCRIPTION
Tweaked the background in dark mode for the notification dropdown so we contrast the reviews better. Looks like this:

<img width="820" alt="foobar" src="https://github.com/user-attachments/assets/51efcc2a-ff0d-4b1b-9849-89b1b430fa26" />
