### PR TITLE
Improve how we handle calculating time since events

### DIFF
--- a/client/src/lib/utils.ts
+++ b/client/src/lib/utils.ts
@@ -86,20 +86,40 @@ export const mod = (n: number, m: number) => ((n % m) + m) % m;
 export const timeSince = (date: Date) => {
   const seconds = Math.floor((new Date().valueOf() - date.valueOf()) / 1000);
 
-  let interval = Math.floor(seconds / 31536000);
-  if (interval > 1) return interval + ' years ago';
+  if (seconds < 60) {
+    return 'just now';
+  }
 
-  interval = Math.floor(seconds / 2592000);
-  if (interval > 1) return interval + ' months ago';
+  const minutes = Math.floor(seconds / 60);
 
-  interval = Math.floor(seconds / 86400);
-  if (interval > 1) return interval + ' days ago';
+  if (minutes < 60) {
+    return minutes === 1 ? '1 minute ago' : `${minutes} minutes ago`;
+  }
 
-  interval = Math.floor(seconds / 3600);
-  if (interval > 1) return interval + ' hours ago';
+  const hours = Math.floor(minutes / 60);
 
-  interval = Math.floor(seconds / 60);
-  if (interval > 1) return interval + ' minutes ago';
+  if (hours < 24) {
+    return hours === 1 ? '1 hour ago' : `${hours} hours ago`;
+  }
 
-  return Math.floor(seconds) + ' seconds ago';
+  const days = Math.floor(hours / 24);
+
+  if (days < 7) {
+    return days === 1 ? '1 day ago' : `${days} days ago`;
+  }
+
+  if (days < 30) {
+    const weeks = Math.floor(days / 7);
+    return weeks === 1 ? '1 week ago' : `${weeks} weeks ago`;
+  }
+
+  const months = Math.floor(days / 30);
+
+  if (months < 12) {
+    return months === 1 ? '1 month ago' : `${months} months ago`;
+  }
+
+  const years = Math.floor(months / 12);
+
+  return years === 1 ? '1 year ago' : `${years} years ago`;
 };


### PR DESCRIPTION
Now we have:

"just now" for < 60 seconds
"1 minute ago" or "X minutes ago" for < 60 minutes
"1 hour ago" or "X hours ago" for < 24 hours
"1 day ago" or "X days ago" for < 7 days
"1 week ago" or "X weeks ago" for < 30 days
"1 month ago" or "X months ago" for < 12 months
"1 year ago" or "X years ago" for ≥ 12 months

Resolves #614 