### PR TITLE
Ensure we have results before handling enter keydown event

### DIFF
--- a/client/src/components/CourseSearchBar.tsx
+++ b/client/src/components/CourseSearchBar.tsx
@@ -122,7 +122,7 @@ export const CourseSearchBar = ({
       );
     }
 
-    if (selectedIndex > -1 && event.key === 'Enter') {
+    if (selectedIndex > -1 && event.key === 'Enter' && length !== 0) {
       navigate(
         selectedIndex < results.courses.length
           ? `/course/${courseIdToUrlParam(results.courses[selectedIndex]._id)}`
@@ -130,6 +130,7 @@ export const CourseSearchBar = ({
               results.instructors[selectedIndex - results.courses.length]
             )}`
       );
+
       if (onResultClick) {
         onResultClick();
         event.currentTarget.blur();


### PR DESCRIPTION
Before this change we could navigate to a nonsensical page from the search bar. This PR now ensures we have results before attempting any sort of navigation upon hitting enter.