### PR TITLE
Select the current term in the schedule display by default

### DIFF
--- a/client/src/components/SchedulesDisplay.tsx
+++ b/client/src/components/SchedulesDisplay.tsx
@@ -5,7 +5,7 @@ import { toast } from 'sonner';
 import { twMerge } from 'tailwind-merge';
 
 import * as buildingCodes from '../assets/buildingCodes.json';
-import { sortTerms } from '../lib/utils';
+import { getCurrentTerm, sortTerms } from '../lib/utils';
 import type { Course } from '../model/Course';
 import type { Block, Schedule } from '../model/Schedule';
 import { Tooltip } from './Tooltip';
@@ -160,6 +160,11 @@ const ScheduleRow = ({ block }: ScheduleRowProps) => {
   );
 };
 
+const getDefaultTerm = (offeredTerms: string[]) => {
+  const currentTerm = getCurrentTerm();
+  return offeredTerms.includes(currentTerm) ? currentTerm : offeredTerms.at(0);
+};
+
 type SchedulesDisplayProps = {
   course: Course;
   className?: string;
@@ -179,7 +184,9 @@ export const SchedulesDisplay = ({
     )
   );
 
-  const [selectedTerm, setSelectedTerm] = useState(offeredTerms.at(0));
+  const [selectedTerm, setSelectedTerm] = useState(
+    getDefaultTerm(offeredTerms)
+  );
   const [showAll, setShowAll] = useState(false);
   const scheduleByTerm = useMemo(() => getSections(schedules), [course]);
   const [blocks, setBlocks] = useState(
@@ -187,7 +194,7 @@ export const SchedulesDisplay = ({
   );
 
   useEffect(() => {
-    setSelectedTerm(offeredTerms.at(0));
+    setSelectedTerm(getDefaultTerm(offeredTerms));
   }, [course]);
 
   useEffect(() => {

--- a/client/src/lib/utils.ts
+++ b/client/src/lib/utils.ts
@@ -41,8 +41,8 @@ export const groupCurrentCourseTermInstructors = (
 export const getCurrentTerms = (): [string, string, string] => {
   const now = new Date();
 
-  const month = now.getMonth() + 1,
-    year = now.getFullYear();
+  const month = now.getMonth() + 1;
+  const year = now.getFullYear();
 
   if (month >= 5 && month < 8) {
     return [`Summer ${year}`, `Fall ${year}`, `Winter ${year + 1}`];
@@ -53,6 +53,29 @@ export const getCurrentTerms = (): [string, string, string] => {
   }
 
   return [`Fall ${year - 1}`, `Winter ${year}`, `Summer ${year}`];
+};
+
+/**
+ * Determines the current academic term based on the current date.
+ * - May-July: Summer <year>
+ * - August-December: Fall <year>
+ * - January-April: Winter <year>
+ * @returns string The current term
+ */
+export const getCurrentTerm = (): string => {
+  const now = new Date();
+  const month = now.getMonth() + 1;
+  const year = now.getFullYear();
+
+  if (month >= 5 && month < 8) {
+    return `Summer ${year}`;
+  }
+
+  if (month >= 8) {
+    return `Fall ${year}`;
+  }
+
+  return `Winter ${year}`;
 };
 
 /**


### PR DESCRIPTION
Uses the current date to display info for a course for the current term, if possible
Ran into the friction of having to select "Winter" to copy CRNs when I was messing around with my course registration, this makes it a bit smoother.
![image](https://github.com/user-attachments/assets/a8fa74cf-8ac7-43c6-97e7-f8afeddcd176)