### PR TITLE
fix "no more courses to show" alignment on mobile

### DIFF
--- a/client/src/pages/Explore.tsx
+++ b/client/src/pages/Explore.tsx
@@ -211,7 +211,7 @@ export const Explore = () => {
                 )}
                 {!hasMore ? (
                   courses?.length ? (
-                    <div className='mx-[200px] mt-4 text-center'>
+                    <div className='mx-auto mt-4 text-center'>
                       <p className='text-gray-500 dark:text-gray-400'>
                         No more courses to show
                       </p>


### PR DESCRIPTION
Before
![image](https://github.com/user-attachments/assets/cdfb9a87-0707-419d-9e87-2f1e7cad40d4)
After
![image](https://github.com/user-attachments/assets/1cb44aa6-5300-44b6-8a1d-f73418bbd088)
