### PR TITLE
Fix duplicate node error when course is both a prerequisite and corequisite

### DIFF
--- a/client/src/components/course-graph.tsx
+++ b/client/src/components/course-graph.tsx
@@ -93,16 +93,32 @@ export const CourseGraph = memo(({ course }: CourseGraphProps) => {
     };
   });
 
-  const graphNodes: Node[] = [
-    {
-      id: course._id,
-      label: spliceCourseCode(course._id, ' '),
-      title: course.description,
-    },
-    ...prereqNodes,
-    ...coreqNodes,
-    ...leading,
-  ];
+  const nodeMap = new Map<string, Node>();
+
+  nodeMap.set(course._id, {
+    id: course._id,
+    label: spliceCourseCode(course._id, ' '),
+    title: course.description,
+  });
+
+  prereqNodes.forEach((node) => nodeMap.set(node.id as string, node));
+
+  coreqNodes.forEach((node) => {
+    const existingNode = nodeMap.get(node.id as string);
+
+    if (existingNode) {
+      nodeMap.set(node.id as string, {
+        ...existingNode,
+        color: 'rgb(255 215 0)',
+      });
+    } else {
+      nodeMap.set(node.id as string, node);
+    }
+  });
+
+  leading.forEach((node) => nodeMap.set(node.id as string, node));
+
+  const graphNodes: Node[] = Array.from(nodeMap.values());
 
   const graph: GraphData = {
     nodes: graphNodes,


### PR DESCRIPTION
Resolves #695 

This PR fixes an issue where if a course is both a prerequisite and a corequisite (a super weird case, thanks McGill), the course graph would break since we're adding a duplicate node. We now detect this, and use a separate color for these nodes, instead of having to remove entries manually from our seed files.