### PR TITLE
Use `tokenize: 'tolerant'` for Flexsearch index

### DIFF
--- a/client/src/lib/searchIndex.ts
+++ b/client/src/lib/searchIndex.ts
@@ -20,7 +20,7 @@ export const getSearchIndex = () => {
 
   if (coursesIndex === null) {
     coursesIndex = new Index({
-      tokenize: 'forward',
+      tokenize: 'tolerant',
     });
 
     courses.forEach((course, i) =>
@@ -53,11 +53,11 @@ export const updateSearchResults = (
   setResults: (_: SearchResults) => void
 ) => {
   const courseSearchResults = coursesIndex
-    .search(query, 4)
+    .search(query, { limit: 4 })
     ?.map((id) => courses[id as number]);
 
   const instructorSearchResults = instructorsIndex
-    .search(query, 2)
+    .search(query, { limit: 4 })
     ?.map((id) => instructors[id as number]);
 
   setResults({


### PR DESCRIPTION
Using `tokenize: 'forward'` gives weird results sometimes, like when searching MATH 222
<img width="1824" height="1064" alt="image" src="https://github.com/user-attachments/assets/afc5e5d4-9232-44cc-ad78-0891b5b174fc" />

`'tolerant'` doesn't have this issue
<img width="956" height="686" alt="image" src="https://github.com/user-attachments/assets/5010b637-fc93-4960-9730-5d8e4072b224" />
