### PR TITLE
Add links to course codes without spaces in requirements section

### DIFF
--- a/client/src/components/course-requirements.tsx
+++ b/client/src/components/course-requirements.tsx
@@ -19,7 +19,7 @@ const stripColonPrefix = (text: string): string => {
 
 const transformText = (text: string): React.ReactNode[] => {
   const nodes = [],
-    regex = /\b([A-Z]{4})\s(\d{3})([A-Za-z]\d?)?\b/g;
+    regex = /\b([A-Z]{4})\s?(\d{3})([A-Za-z]\d?)?\b/g;
 
   let lastIndex = 0;
 


### PR DESCRIPTION
This PR updates the course code regex pattern in the requirements component to match course codes both with and without spaces between the department code and course number.

Before:

<img width="378" height="162" alt="Screenshot 2025-09-30 at 1 33 17 AM" src="https://github.com/user-attachments/assets/1b934c2e-b667-4f5e-8122-1608f874fabf" />

After:

<img width="473" height="121" alt="Screenshot 2025-09-30 at 1 33 32 AM" src="https://github.com/user-attachments/assets/20df55bf-cdbd-4021-8fc1-a8e030a36acd" />