### PR TITLE
Remove superfluous initialization from husky pre-commit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,3 @@
 #!/bin/sh
 
-. "$(dirname "$0")/_/husky.sh"
-
 npx lint-staged


### PR DESCRIPTION
Getting a warning that it will be deprecated in a future release.