### PR TITLE
Remove changelog from footer and sidebar

### DIFF
--- a/client/src/components/footer.tsx
+++ b/client/src/components/footer.tsx
@@ -6,7 +6,6 @@ import { NavItem } from './nav-item';
 export const navigationItems = [
   { name: 'Home', href: '/' },
   { name: 'About', href: '/about' },
-  { name: 'Changelog', href: '/changelog' },
   { name: 'Explore', href: '/explore' },
   { name: 'Reviews', href: '/reviews' },
   { name: 'Schedule Builder', href: '/schedule-builder' },


### PR DESCRIPTION
Removes the Changelog link from the shared navigation items used by both the footer and the sidebar. The /changelog page itself remains accessible.