### PR TITLE
Add term field to course reviews

### DIFF
--- a/client/src/components/add-review-form.tsx
+++ b/client/src/components/add-review-form.tsx
@@ -5,6 +5,7 @@ import { toast } from 'sonner';
 
 import { api } from '../lib/api';
 import type { Course } from '../lib/types';
+import { getCurrentTerm } from '../lib/utils';
 import {
   ReviewForm,
   ReviewFormInitialValues,
@@ -29,6 +30,7 @@ export const AddReviewForm = ({
     difficulty: 0,
     instructors: [],
     rating: 0,
+    term: getCurrentTerm(),
   };
 
   const handleClose = () => {

--- a/client/src/components/edit-review-form.tsx
+++ b/client/src/components/edit-review-form.tsx
@@ -5,6 +5,7 @@ import { toast } from 'sonner';
 
 import { api } from '../lib/api';
 import type { Course, Review } from '../lib/types';
+import { getCurrentTerm } from '../lib/utils';
 import {
   ReviewForm,
   ReviewFormInitialValues,
@@ -31,6 +32,7 @@ export const EditReviewForm = ({
     difficulty: review.difficulty,
     instructors: review.instructors,
     rating: review.rating,
+    term: review.term ?? getCurrentTerm(),
   };
 
   const handleClose = () => {

--- a/client/src/components/review-form.test.tsx
+++ b/client/src/components/review-form.test.tsx
@@ -40,6 +40,9 @@ vi.mock('lucide-react', () => ({
   Flame: (props: Record<string, unknown>) => (
     <svg data-testid='flame-icon' {...props} />
   ),
+  ChevronDown: (props: Record<string, unknown>) => (
+    <svg data-testid='chevron-down-icon' {...props} />
+  ),
 }));
 
 vi.mock('./bird-icon', () => ({

--- a/client/src/components/review-form.tsx
+++ b/client/src/components/review-form.tsx
@@ -5,9 +5,11 @@ import { PropsWithChildren } from 'react';
 import * as Yup from 'yup';
 
 import type { AddOrUpdateReviewBody, Course } from '../lib/types';
+import { compareTerms, getCurrentTerm, getRecentTerms } from '../lib/utils';
 import { BirdIcon } from './bird-icon';
 import { IconRatingInput } from './icon-rating-input';
 import { MultiSelect } from './ui/multi-select';
+import { Select } from './ui/select';
 
 export const ReviewSchema = Yup.object().shape({
   content: Yup.string()
@@ -22,6 +24,7 @@ export const ReviewSchema = Yup.object().shape({
     .min(1, 'Difficulty must be between 1 and 5')
     .max(5, 'Difficulty must be between 1 and 5')
     .required('Difficulty is required'),
+  term: Yup.string(),
 });
 
 type FieldErrorProps = {
@@ -99,6 +102,10 @@ export const ReviewForm = ({
 
   instructorNames.push('Other');
 
+  const termOptions: string[] = Array.from(
+    new Set([...course.terms, ...getRecentTerms()])
+  ).sort(compareTerms);
+
   return (
     <>
       <FieldLabel htmlFor='instructors'>Instructor(s)</FieldLabel>
@@ -111,6 +118,15 @@ export const ReviewForm = ({
         values={values.instructors}
       />
       <FieldError name='instructors' />
+
+      <FieldLabel htmlFor='term'>Term</FieldLabel>
+      <Select
+        className='mt-2'
+        options={termOptions}
+        value={values.term ?? getCurrentTerm()}
+        setValue={(term) => setFieldValue('term', term)}
+      />
+
       <div className='flex gap-x-10'>
         <div className='flex flex-col gap-y-1'>
           <FieldLabel htmlFor='rating'>Rating</FieldLabel>

--- a/client/src/lib/types.ts
+++ b/client/src/lib/types.ts
@@ -13,6 +13,8 @@ export interface AddOrUpdateReviewBody {
   rating: number;
   /** Difficulty rating out of 5 (1-5). */
   difficulty: number;
+  /** The term the review is for (e.g. "Fall 2025"). */
+  term?: string;
 }
 
 export interface TimeBlock {

--- a/client/src/lib/types.ts
+++ b/client/src/lib/types.ts
@@ -207,6 +207,8 @@ export interface Review {
   rating: number;
   /** Timestamp when the review was created or last updated. */
   timestamp: string;
+  /** The term this review was written for (e.g. "Fall 2025"). */
+  term?: string;
   /** The user ID of the review author. */
   userId: string;
 }

--- a/client/src/lib/utils.ts
+++ b/client/src/lib/utils.ts
@@ -156,6 +156,34 @@ export const getCurrentTerms = (): [string, string, string] => {
 };
 
 /**
+ * Returns a chronological range of academic terms centered on the current term,
+ * spanning back through last year's equivalent term and forward through the
+ * next two terms. Useful as a term picker's option list when no other source
+ * of valid terms (e.g. a course's offered terms) is available.
+ *
+ * @returns {string[]} Terms in chronological order, oldest first
+ */
+export const getRecentTerms = (): string[] => {
+  const [currentSeason, currentYearString] = getCurrentTerm().split(' ');
+  const currentYear = parseInt(currentYearString, 10);
+  const currentIndex = TERM_ORDER.indexOf(currentSeason);
+
+  const termsBack = 3;
+  const termsForward = 2;
+
+  const terms: string[] = [];
+
+  for (let offset = -termsBack; offset <= termsForward; offset++) {
+    const index = currentIndex + offset;
+    const season = TERM_ORDER[((index % 3) + 3) % 3];
+    const year = currentYear + Math.floor(index / 3);
+    terms.push(`${season} ${year}`);
+  }
+
+  return terms;
+};
+
+/**
  * Generates a stable DOM anchor identifier for a review.
  *
  * Uses the author ID, which is unique per course review, to produce repeatable anchors.

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -3,7 +3,7 @@
     "allowJs": false,
     "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": true,
-    "ignoreDeprecations": "6.0",
+    "ignoreDeprecations": "5.0",
     "isolatedModules": true,
     "jsx": "react-jsx",
     "lib": ["DOM", "DOM.Iterable", "ESNext"],

--- a/crates/model/src/review.rs
+++ b/crates/model/src/review.rs
@@ -21,6 +21,8 @@ pub struct Review {
   /// Timestamp when the review was created or last updated.
   #[typeshare(serialized_as = "String")]
   pub timestamp: DateTime,
+  /// The term this review was written for (e.g. "Fall 2025").
+  pub term: Option<String>,
   /// The user ID of the review author.
   pub user_id: String,
 }
@@ -35,6 +37,7 @@ impl Default for Review {
       likes: 0,
       rating: 0,
       timestamp: DateTime::from_millis(0),
+      term: None,
       user_id: String::new(),
     }
   }
@@ -50,6 +53,7 @@ impl Into<Bson> for Review {
       "rating": self.rating,
       "timestamp": self.timestamp.timestamp_millis().to_string(),
       "userId": self.user_id,
+      "term": self.term,
       "likes": self.likes
     })
   }

--- a/crates/model/src/review.rs
+++ b/crates/model/src/review.rs
@@ -78,6 +78,7 @@ mod tests {
       likes: 5,
       rating: 4,
       timestamp,
+      term: None,
       user_id: "user123".to_string(),
     };
 
@@ -249,6 +250,7 @@ mod tests {
       likes: 10,
       rating: 5,
       timestamp: DateTime::from_millis(1672531200000), // 2023-01-01 00:00:00 UTC
+      term: None,
       user_id: "user456".to_string(),
     };
 
@@ -258,5 +260,42 @@ mod tests {
       serde_json::from_value(json).expect("failed to deserialize");
 
     assert_eq!(original, deserialized);
+  }
+
+  #[test]
+  fn serialize_term_when_present() {
+    let review = Review {
+      content: "Amazing course".to_string(),
+      course_id: "CSC101".to_string(),
+      difficulty: 3,
+      instructors: vec![],
+      likes: 0,
+      rating: 4,
+      timestamp: DateTime::from_millis(1640995200000),
+      user_id: "user123".to_string(),
+      term: Some("Fall 2025".to_string()),
+    };
+
+    let json = serde_json::to_value(&review).expect("failed to serialize");
+    assert_eq!(json["term"], Value::String("Fall 2025".to_string()));
+  }
+
+  #[test]
+  fn serialize_term_when_absent() {
+    let review = Review {
+      content: "Great course".to_string(),
+      course_id: "COMP101".to_string(),
+      difficulty: 3,
+      instructors: vec![],
+      likes: 0,
+      rating: 4,
+      timestamp: DateTime::from_millis(1640995200000),
+      user_id: "user123".to_string(),
+      term: None,
+    };
+
+  let json = serde_json::to_value(&review).expect("failed to serialize");
+
+  assert!(json["term"].is_null());
   }
 }

--- a/src/reviews.rs
+++ b/src/reviews.rs
@@ -238,6 +238,8 @@ pub struct AddOrUpdateReviewBody {
   pub(crate) rating: u32,
   /// Difficulty rating out of 5 (1-5).
   pub(crate) difficulty: u32,
+  /// The term the review is for (e.g. "Fall 2025").
+  pub(crate) term: Option<String>,
 }
 
 impl AddOrUpdateReviewBody {
@@ -326,6 +328,7 @@ pub(crate) async fn add_review(
     instructors,
     rating,
     difficulty,
+    term,
   } = body.0;
 
   let user_id = user.id();
@@ -342,6 +345,7 @@ pub(crate) async fn add_review(
     difficulty,
     instructors,
     rating,
+    term,
     timestamp: Utc::now().into(),
     user_id,
     ..Review::default()
@@ -399,6 +403,7 @@ pub(crate) async fn update_review(
     instructors,
     rating,
     difficulty,
+    term,
   } = body.0;
 
   validate_instructors(db.clone(), &course_id, &instructors).await?;
@@ -413,6 +418,7 @@ pub(crate) async fn update_review(
     instructors,
     rating,
     difficulty,
+    term,
     timestamp: Utc::now().into(),
     user_id: user_id.clone(),
     ..Review::default()

--- a/src/server.rs
+++ b/src/server.rs
@@ -3263,6 +3263,7 @@ mod tests {
         likes: 0,
         rating: 5,
         timestamp: reviews[0].timestamp.clone(),
+        term: None,
         user_id: "test".into(),
       }]
     );


### PR DESCRIPTION
## What does this PR do?

  Adds an optional `term` field to course reviews, letting
  users select which term (e.g. "Fall 2025") a review was
  written for. This includes the `term` field on the
  `Review` model and `AddOrUpdateReviewBody` request type
  (server + generated TS types), a term selector in the
  add/edit review form, and corresponding test coverage on
  both the Rust and client sides.

  ## Why was this PR needed?

  Reviews previously had no way to indicate which term a
  course was taken in, making it harder for students to
  judge whether a review is still relevant (e.g. after an
  instructor or course format change). This PR adds that
  context directly to the review data model and UI.

  ## What are the relevant issue numbers?

  Closes #771

  ## Does this PR meet the acceptance criteria?

  - [ ] Tests added for new/changed behavior
  - [x] All tests passing
  - [x] Follows project style guide
  - [x] No breaking changes introduced